### PR TITLE
Update data to allow models to leverage initial condition after gap

### DIFF
--- a/R/get_regime.R
+++ b/R/get_regime.R
@@ -51,6 +51,8 @@ get_regime <- function(regime = 4, test = "out") {
                   transition 4: newmoon 396:411: Jun 2009 - Sep 2010")
   }
 
+  gap <- transition_stop - regime_stop + 1
+
   if (test == "out") {
     train_start <- regime_stop - 60
     train_stop <- regime_stop - 1
@@ -59,7 +61,6 @@ get_regime <- function(regime = 4, test = "out") {
   }
 
   if (test == "in") {
-    gap <- transition_stop - regime_stop + 1
     train_start <- regime_stop - 13 - gap - 60
     train_stop <- regime_stop - 13 - gap - 1
     test_start <- regime_stop - 13
@@ -70,6 +71,7 @@ get_regime <- function(regime = 4, test = "out") {
     train_start = train_start,
     train_stop = train_stop,
     test_start = test_start,
-    test_stop = test_stop
+    test_stop = test_stop,
+    gap = gap
   ))
 }


### PR DESCRIPTION
We want the model to start with the initial condition of abundance for
the first observation following the regime shift gap. The simplest way
to do this is to keepp the gap and the first newmoon post regime shift
in data_train and fill the y values for the gap (but not the initial
condition newmoon) with NA's and then start the test set on the newmoon
following the intial condition. This does technically allow the model to
train on the initial condition point, but that's only 1 data point about
of 61 and the bias should make our result conservative. If we want to
improve this in the future we'll need a particle filter instead.
